### PR TITLE
Only run "ensure jenkins is running" if jenkins actually isn't running

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -112,4 +112,8 @@ end
 log "ensure_jenkins_is_running" do
   notifies :start, "service[jenkins]", :immediately
   notifies :create, "ruby_block[block_until_operational]", :immediately
+  not_if {
+      test_url = URI.parse("#{node['jenkins']['server']['url']}/api/json")
+      JenkinsHelper.endpoint_responding?(test_url)
+  }
 end


### PR DESCRIPTION
We don't want this to run every single time chef runs
