### PR TITLE
Use a yola apt mirror for jenkins package

### DIFF
--- a/recipes/_master_package.rb
+++ b/recipes/_master_package.rb
@@ -26,7 +26,7 @@ when 'debian'
   include_recipe 'apt::default'
 
   apt_repository 'jenkins' do
-    uri          'http://pkg.jenkins-ci.org/debian'
+    uri          'http://apt-mirrors.yola.net/jenkins'
     distribution 'binary/'
     key          '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6'
     keyserver    'pool.sks-keyservers.net'


### PR DESCRIPTION
Cause the jenkins mirror sucks.
